### PR TITLE
feat: add --fail-fast option

### DIFF
--- a/docs/rpt.1
+++ b/docs/rpt.1
@@ -17,6 +17,10 @@ Run \fBCOMMAND ARGUMENTS\fR TIMES times.
 
 .SH OPTIONS
 .TP
+\fB--fail-fast\fP
+if command fails exit immediately with the same exit code as command.
+
+.TP
 \fB-d=DURATION, --delay=DURATION\fP
 wait \fBDURATION\fR between runs (default: 0s)
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,6 +14,9 @@ Run `COMMAND ARGUMENTS` TIMES times.
 
 # OPTIONS
 
+**--fail-fast**
+: if command fails exit immediately with the same exit code as command.
+
 **-d=DURATION, --delay=DURATION**
 : wait `DURATION` between runs (default: 0s)
 

--- a/testdata/fail-fast.golden
+++ b/testdata/fail-fast.golden
@@ -1,0 +1,2 @@
+Doing nothing unsuccessfully
+exit status 1

--- a/testdata/fail/main.go
+++ b/testdata/fail/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	fmt.Println("Doing nothing unsuccessfully")
+	os.Exit(1)
+}

--- a/testdata/help.golden
+++ b/testdata/help.golden
@@ -15,6 +15,7 @@ AUTHOR:
 
 OPTIONS:
    --delay DURATION, -d DURATION  wait DURATION between runs (default: 0s)
+   --fail-fast                    if command fails exit immediately with the same exit code as command. (default: false)
    --verbose, -v                  print debugging messages (default: false)
    --help, -h                     show help
    --version                      print the version

--- a/testdata/no-fail-fast.golden
+++ b/testdata/no-fail-fast.golden
@@ -1,0 +1,4 @@
+Doing nothing unsuccessfully
+exit status 1
+Doing nothing unsuccessfully
+exit status 1


### PR DESCRIPTION
If the command exits with a non-zero exit code and --fail-fast is provided, do not run the command again; do not sleep; exit immediately with command's exit code.