### PR TITLE
Feat/edge support

### DIFF
--- a/docs/rpt.1
+++ b/docs/rpt.1
@@ -18,7 +18,15 @@ Run \fBCOMMAND ARGUMENTS\fR TIMES times.
 .SH OPTIONS
 .TP
 \fB--fail-fast\fP
-if command fails exit immediately with the same exit code as command.
+if command fails exit immediately with the same exit
+code as command
+
+.TP
+\fB--leading-edge\fP
+if given, any provided delay is between the start of
+one command invocation and the start of the next.  If
+not given, any provided delay is between the end of
+one command invocation and the start of the next
 
 .TP
 \fB-d=DURATION, --delay=DURATION\fP

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -15,7 +15,15 @@ Run `COMMAND ARGUMENTS` TIMES times.
 # OPTIONS
 
 **--fail-fast**
-: if command fails exit immediately with the same exit code as command.
+: if command fails exit immediately with the same exit
+	code as command
+
+**--leading-edge**
+: if given, any provided delay is between the start of
+	one command invocation and the start of the next.  If
+	not given, any provided delay is between the end of
+	one command invocation and the start of the next
+	
 
 **-d=DURATION, --delay=DURATION**
 : wait `DURATION` between runs (default: 0s)

--- a/internal/app.go
+++ b/internal/app.go
@@ -93,19 +93,7 @@ func runRepeatedly(ctx *cli.Context) error {
 	failFast := ctx.Bool("fail-fast")
 	delay := ctx.Duration("delay")
 	for i := range times {
-		if i != 0 {
-			if verbose {
-				log.Printf("sleeping=%s\n", delay)
-			}
-			time.Sleep(delay)
-		}
-		args := make([]string, ctx.Args().Len()-2)
-		for i, arg := range ctx.Args().Slice() {
-			if i >= 2 {
-				args[i-2] = arg
-			}
-		}
-		cmd := exec.Command(ctx.Args().Get(1), args...)
+		cmd := buildCommand(ctx)
 		if verbose {
 			log.Printf("Iteration=%d; running cmd=%s\n", i, cmd.String())
 		}
@@ -118,9 +106,26 @@ func runRepeatedly(ctx *cli.Context) error {
 				log.Printf("%s\n", err)
 			}
 		}
+		if i != times-1 {
+			if verbose {
+				log.Printf("sleeping=%s\n", delay)
+			}
+			time.Sleep(delay)
+		}
 	}
 	return nil
 
+}
+
+func buildCommand(ctx *cli.Context) *exec.Cmd {
+	args := make([]string, ctx.Args().Len()-2)
+	for i, arg := range ctx.Args().Slice() {
+		if i >= 2 {
+			args[i-2] = arg
+		}
+	}
+	cmd := exec.Command(ctx.Args().Get(1), args...)
+	return cmd
 }
 
 func runOnce(cmd *exec.Cmd) error {

--- a/main_test.go
+++ b/main_test.go
@@ -52,6 +52,20 @@ func TestDelay(t *testing.T) {
 			3,
 			0,
 		},
+		{
+			"leading edge; invocation duration less than delay",
+			"There is a 2s delay between start of invocations.  The 1s sleep inside invocation is not relevant as it is less than the 2s delay.",
+			[]string{"--leading-edge", "--delay", "2s", "3", "bash", "-c", "sleep 1; date +%s"},
+			2,
+			0,
+		},
+		{
+			"Run date every 2s - leading edge; invocation exceeds delay",
+			"2s sleep inside invocation determines period. 1s delay between start of invocations is not relevant as invocation exceeds delay and we're using leading edge.",
+			[]string{"--leading-edge", "--delay", "1s", "3", "bash", "-c", "sleep 2; date +%s"},
+			2,
+			0,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.testName, func(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -31,24 +31,34 @@ func TestMain(m *testing.M) {
 }
 
 func TestDelay(t *testing.T) {
-	var delay int64 = 1
-	args := []string{"--delay", "1s", "3", "date", "+%s"}
-	output, err := runBinary(args)
-	assertExitCode(t, output, 0, err)
-
-	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
-	var priorTimestamp int64
-	for _, line := range lines {
-		timestamp, err := strconv.ParseInt(line, 10, 64)
-		if err != nil {
-			t.Fatalf("failed to parse timestamp %s, %s", line, err)
-		}
-		if priorTimestamp != 0 {
-			if priorTimestamp+delay != timestamp {
-				t.Fatalf("expected timestamp %d to be %d seconds after prior timestamp %d", timestamp, delay, priorTimestamp)
-			}
-		}
-		priorTimestamp = timestamp
+	tests := []struct {
+		testName         string
+		testDescription  string
+		optionsAndArgs   []string
+		expectedDelay    int64
+		expectedExitCode int
+	}{
+		{
+			"Run date every 1s",
+			"",
+			[]string{"--delay", "1s", "3", "date", "+%s"},
+			1,
+			0,
+		},
+		{
+			"trailing edge",
+			"Run date every 3s.  There is a 2s delay between the end of one invocation and start of next along with a 1s sleep inside the invocation.",
+			[]string{"--delay", "2s", "3", "bash", "-c", "sleep 1; date +%s"},
+			3,
+			0,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.testName, func(t *testing.T) {
+			output, err := runBinary(tt.optionsAndArgs)
+			assertExitCode(t, output, tt.expectedExitCode, err)
+			assertTimestamps(t, output, tt.expectedDelay)
+		})
 	}
 }
 
@@ -147,5 +157,34 @@ func assertExitCode(t *testing.T, output []byte, expectedExitCode int, err error
 		} else {
 			t.Fatalf("output:\n%s\nerror:\n%s\n", output, err)
 		}
+	}
+}
+
+func assertTimestamps(t *testing.T, output []byte, expectedDelay int64) {
+	t.Helper()
+	lines := strings.Split(strings.TrimSpace(string(output)), "\n")
+	var priorTimestamp int64
+	for _, line := range lines {
+		timestamp, err := strconv.ParseInt(line, 10, 64)
+		if err != nil {
+			t.Fatalf("failed to parse timestamp %s, %s", line, err)
+		}
+		if priorTimestamp != 0 {
+			if priorTimestamp+expectedDelay != timestamp {
+				beforeOrAfter := "before"
+				if priorTimestamp <= timestamp {
+					beforeOrAfter = "after"
+				}
+				t.Fatalf(
+					"expected timestamp %d to be %d seconds after prior timestamp %d, but was %d seconds %s",
+					timestamp,
+					expectedDelay,
+					priorTimestamp,
+					timestamp-priorTimestamp,
+					beforeOrAfter,
+				)
+			}
+		}
+		priorTimestamp = timestamp
 	}
 }

--- a/testdata/help.golden
+++ b/testdata/help.golden
@@ -15,7 +15,13 @@ AUTHOR:
 
 OPTIONS:
    --delay DURATION, -d DURATION  wait DURATION between runs (default: 0s)
-   --fail-fast                    if command fails exit immediately with the same exit code as command. (default: false)
+   --leading-edge                 if given, any provided delay is between the start of
+                                  one command invocation and the start of the next.  If
+                                  not given, any provided delay is between the end of
+                                  one command invocation and the start of the next
+                                   (default: false)
+   --fail-fast                    if command fails exit immediately with the same exit
+                                  code as command (default: false)
    --verbose, -v                  print debugging messages (default: false)
    --help, -h                     show help
    --version                      print the version


### PR DESCRIPTION
The given delay between command invocations can now either be between the start of one invocation and the start of the next, or between the end of one invocation and the start of the next.  It defaults to the latter.  If the former, and the command takes longer to execute than the delay, the command will be immediately re-ran.